### PR TITLE
Update PrefActivity.java

### DIFF
--- a/src/com/owentech/DevDrawer/activities/PrefActivity.java
+++ b/src/com/owentech/DevDrawer/activities/PrefActivity.java
@@ -118,7 +118,13 @@ public class PrefActivity extends PreferenceActivity
                 return true;
             }
         });
-	}
+     
+    	// disable root views if no root access   
+        if(!rootPref.isChecked()) {
+        	toggleRootViews(false);
+        }
+        
+    }
 
     @Override
     public void onBackPressed() {


### PR DESCRIPTION
There is a bug in a Preference screen. Also if you don't have root access on your phone, you can at first entering the screen to set "uninstall" and "remove cache" CheckBoxPreferences to 'checked' and widget will be updated, corresponding to this new preferences. So, this is a bug.
Of course without root access you can't 'remove cache' and you will get Toast of "no root access", but this is a bad design itself.
So, I think we need to check state of a rootPref and if it is not checked – disable rootViews
