### PR TITLE
Fixed issue where a widget name with an apostrophe would FC app.

### DIFF
--- a/DevDrawer/src/main/java/com/owentech/DevDrawer/utils/Database.java
+++ b/DevDrawer/src/main/java/com/owentech/DevDrawer/utils/Database.java
@@ -104,7 +104,7 @@ public class Database {
 
     public void renameWidget(int widgetId, String name) {
         connectDB();
-        db.execSQL("UPDATE devdrawer_widgets SET name='" + name + "' WHERE id ='" + widgetId + "'");
+        db.execSQL("UPDATE devdrawer_widgets SET name='" + name.replace("'","''") + "' WHERE id ='" + widgetId + "'");
         closeDB();
     }
 


### PR DESCRIPTION
Came across this bug accidentally. I use Minuum, so every character you type changes the entire word. I was writing one word and it changed to "Let's", which FC'd when trying to update the DB. Just a small fix to correct this issue.
